### PR TITLE
Merge pull request #64 from PhotoFilmStrip/fix-issue63

### DIFF
--- a/photofilmstrip/action/ActionI18N.py
+++ b/photofilmstrip/action/ActionI18N.py
@@ -40,6 +40,6 @@ class ActionI18N(IAction):
             lang = gettext.translation(Constants.APP_NAME,
                                        localeDir,
                                        languages=[curLang, "en"])
-            lang.install(True)
+            lang.install()
         except IOError:
             gettext.install(Constants.APP_NAME)


### PR DESCRIPTION
lang.install does not need unicode flag anymore

(cherry picked from commit a7b1c1cf6f3aef037081e2d1c066d0b87f078e9b)